### PR TITLE
Add tests for minimal dependencies.

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 [meta]
 template = "pure-python"
-commit-id = "75c6251b"
+commit-id = "0754ed06"
 
 [python]
 with-macos = false
@@ -14,6 +14,20 @@ with-sphinx-doctests = true
 
 [tox]
 use-flake8 = true
+additional-envlist = [
+    "py311-minimal",
+    "py311-component",
+]
+testenv-additional = [
+    "",
+    "[testenv:py311-minimal]",
+    "extras = test-minimal",
+    "commands = zope-testrunner --test-path=src {posargs:-vc}",
+    "",
+    "[testenv:py311-component]",
+    "extras = test-component",
+    "commands = zope-testrunner --test-path=src {posargs:-vc}",
+]
 
 [coverage]
 fail-under = 100

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@
 
 - Drop support for Python 3.7, 3.8.
 
+- Add tests for minimal dependencies.
+
+- Add ``copy`` extra to include the ``zope.copy`` dependency.
 
 5.0 (2023-05-25)
 ================

--- a/setup.py
+++ b/setup.py
@@ -29,84 +29,73 @@ def read(*rnames):
         return f.read()
 
 
-ZCML_REQUIRES = [
-    'zope.configuration',
-]
-
-COMPONENT_REQUIRES = [
-    'zope.component >= 4.0.1',
-]
-
-COPY_REQUIRES = [
-    'zope.copy >= 4.0',
-]
-
-TESTS_REQUIRE = [
-    'zope.testrunner',
-]
-
-DOCS_REQUIRE = [
-    'Sphinx',
-    'repoze.sphinx.autointerface',
-] + ZCML_REQUIRES + COMPONENT_REQUIRES  # doctest snippets need these
-
-setup(name='zope.location',
-      version='5.1.dev0',
-      author='Zope Foundation and Contributors',
-      author_email='zope-dev@zope.dev',
-      description='Zope Location',
-      long_description=(
-          read('README.rst')
-          + '\n\n' +
-          read('CHANGES.rst')
-      ),
-      license='ZPL-2.1',
-      keywords=('zope location structural'),
-      classifiers=[
-          'Development Status :: 5 - Production/Stable',
-          'Environment :: Web Environment',
-          'Intended Audience :: Developers',
-          'License :: OSI Approved :: Zope Public License',
-          'Programming Language :: Python',
-          'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.9',
-          'Programming Language :: Python :: 3.10',
-          'Programming Language :: Python :: 3.11',
-          'Programming Language :: Python :: 3.12',
-          'Programming Language :: Python :: 3.13',
-          'Programming Language :: Python :: Implementation :: CPython',
-          'Programming Language :: Python :: Implementation :: PyPy',
-          'Natural Language :: English',
-          'Operating System :: OS Independent',
-          'Topic :: Internet :: WWW/HTTP',
-          'Framework :: Zope :: 3',
-          'Framework :: Zope :: 5',
-      ],
-      url='http://github.com/zopefoundation/zope.location/',
-      packages=find_packages('src'),
-      package_dir={'': 'src'},
-      namespace_packages=['zope', ],
-      python_requires='>=3.9',
-      install_requires=[
-          'setuptools',
-          'zope.interface>=4.0.2',
-          'zope.schema>=4.2.2',
-          'zope.proxy>=4.0.1',
-      ],
-      extras_require={
-          'zcml': ZCML_REQUIRES,
-          'component': COMPONENT_REQUIRES,
-          'copy': COPY_REQUIRES,
-          'test-minimal': TESTS_REQUIRE,
-          'test-component': TESTS_REQUIRE + COMPONENT_REQUIRES + ZCML_REQUIRES,
-          'test': (
-              TESTS_REQUIRE
-              + ZCML_REQUIRES
-              + COMPONENT_REQUIRES
-              + COPY_REQUIRES
-          ),
-          'docs': DOCS_REQUIRE,
-      },
-      include_package_data=True,
-      zip_safe=False,
-      )
+setup(
+    name='zope.location',
+    version='5.1.dev0',
+    author='Zope Foundation and Contributors',
+    author_email='zope-dev@zope.dev',
+    description='Zope Location',
+    long_description=(
+        read('README.rst') + '\n\n' + read('CHANGES.rst')),
+    license='ZPL-2.1',
+    keywords=('zope location structural'),
+    classifiers=[
+            'Development Status :: 5 - Production/Stable',
+            'Environment :: Web Environment',
+            'Intended Audience :: Developers',
+            'License :: OSI Approved :: Zope Public License',
+            'Programming Language :: Python',
+            'Programming Language :: Python :: 3',
+            'Programming Language :: Python :: 3.9',
+            'Programming Language :: Python :: 3.10',
+            'Programming Language :: Python :: 3.11',
+            'Programming Language :: Python :: 3.12',
+            'Programming Language :: Python :: 3.13',
+            'Programming Language :: Python :: Implementation :: CPython',
+            'Programming Language :: Python :: Implementation :: PyPy',
+            'Natural Language :: English',
+            'Operating System :: OS Independent',
+            'Topic :: Internet :: WWW/HTTP',
+            'Framework :: Zope :: 3',
+            'Framework :: Zope :: 5',
+    ],
+    url='http://github.com/zopefoundation/zope.location/',
+    packages=find_packages('src'),
+    package_dir={
+        '': 'src'},
+    namespace_packages=[
+        'zope',
+    ],
+    python_requires='>=3.9',
+    install_requires=[
+        'setuptools',
+        'zope.interface>=4.0.2',
+        'zope.schema>=4.2.2',
+        'zope.proxy>=4.0.1',
+    ],
+    extras_require={
+        'zcml': ['zope.configuration'],
+        'component': ['zope.component >= 4.0.1'],
+        'copy': ['zope.copy >= 4.0'],
+        'test-minimal': ['zope.testrunner'],
+        'test-component': [
+            'zope.testrunner',
+            'zope.component >= 4.0.1',
+            'zope.configuration',
+        ],
+        'test': [
+            'zope.testrunner',
+            'zope.configuration',
+            'zope.component >= 4.0.1',
+            'zope.copy >= 4.0',
+        ],
+        'docs': [
+            'repoze.sphinx.autointerface',
+            'Sphinx',
+            'zope.component >= 4.0.1',
+            'zope.configuration',
+        ],
+    },
+    include_package_data=True,
+    zip_safe=False,
+)

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,11 @@ COMPONENT_REQUIRES = [
     'zope.component >= 4.0.1',
 ]
 
-TESTS_REQUIRE = ZCML_REQUIRES + COMPONENT_REQUIRES + [
+COPY_REQUIRES = [
     'zope.copy >= 4.0',
+]
+
+TESTS_REQUIRE = [
     'zope.testrunner',
 ]
 
@@ -57,7 +60,7 @@ setup(name='zope.location',
           + '\n\n' +
           read('CHANGES.rst')
       ),
-      license='ZPL 2.1',
+      license='ZPL-2.1',
       keywords=('zope location structural'),
       classifiers=[
           'Development Status :: 5 - Production/Stable',
@@ -93,7 +96,15 @@ setup(name='zope.location',
       extras_require={
           'zcml': ZCML_REQUIRES,
           'component': COMPONENT_REQUIRES,
-          'test': TESTS_REQUIRE,
+          'copy': COPY_REQUIRES,
+          'test-minimal': TESTS_REQUIRE,
+          'test-component': TESTS_REQUIRE + COMPONENT_REQUIRES + ZCML_REQUIRES,
+          'test': (
+              TESTS_REQUIRE
+              + ZCML_REQUIRES
+              + COMPONENT_REQUIRES
+              + COPY_REQUIRES
+          ),
           'docs': DOCS_REQUIRE,
       },
       include_package_data=True,

--- a/src/zope/location/testing.py
+++ b/src/zope/location/testing.py
@@ -1,0 +1,10 @@
+import importlib
+import unittest
+
+
+def skipUnlessImportable(module: str):
+    try:
+        importlib.import_module(module)
+    except ModuleNotFoundError:  # pragma: no cover
+        return unittest.skip(f"{module!r} not importable")
+    return lambda func: func

--- a/src/zope/location/tests/test_configure.py
+++ b/src/zope/location/tests/test_configure.py
@@ -15,12 +15,22 @@
 """
 import unittest
 
+from zope.location.testing import skipUnlessImportable
 
+
+@skipUnlessImportable('zope.component')
 class Test_ZCML_loads(unittest.TestCase):
 
     def test_it(self):
         import zope.component  # no registrations made if not present
-        ADAPTERS_REGISTERED = 4
+
+        try:
+            import zope.copy
+            ADAPTERS_REGISTERED = 4
+        except ModuleNotFoundError:  # pragma: no cover
+            ADAPTERS_REGISTERED = 3
+        else:
+            del zope.copy
         from zope.configuration.xmlconfig import XMLConfig
         from zope.configuration.xmlconfig import _clearContext
         from zope.configuration.xmlconfig import _getContext

--- a/src/zope/location/tests/test_pickling.py
+++ b/src/zope/location/tests/test_pickling.py
@@ -13,7 +13,10 @@
 ##############################################################################
 import unittest
 
+from zope.location.testing import skipUnlessImportable
 
+
+@skipUnlessImportable('zope.copy')
 class LocationCopyHookTests(unittest.TestCase):
 
     def _getTargetClass(self):

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,8 @@ envlist =
     pypy3
     docs
     coverage
+    py311-minimal
+    py311-component
 
 [testenv]
 usedevelop = true
@@ -26,6 +28,14 @@ commands =
 extras =
     test
     docs
+
+[testenv:py311-minimal]
+extras = test-minimal
+commands = zope-testrunner --test-path=src {posargs:-vc}
+
+[testenv:py311-component]
+extras = test-component
+commands = zope-testrunner --test-path=src {posargs:-vc}
 
 [testenv:setuptools-latest]
 basepython = python3


### PR DESCRIPTION
Add `copy` extra to include the `zope.copy` dependency.

Fixes #5.